### PR TITLE
Add api /orai-info

### DIFF
--- a/packages/oraidex-server/package.json
+++ b/packages/oraidex-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oraichain/oraidex-server",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "main": "dist/index.js",
   "bin": "dist/index.js",
   "license": "MIT",

--- a/packages/oraidex-server/package.staging.json
+++ b/packages/oraidex-server/package.staging.json
@@ -1,6 +1,6 @@
 {
   "name": "@oraichain/oraidex-server-staging",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "dist/index.js",
   "bin": "dist/index.js",
   "license": "MIT",

--- a/packages/oraidex-sync/src/db.ts
+++ b/packages/oraidex-sync/src/db.ts
@@ -506,6 +506,20 @@ export class DuckDb {
     return result[0] as PoolAmountHistory;
   }
 
+  async getLpAmountWithTime(pairAddr: string, timestamp: number) {
+    const result = await this.conn.all(
+      `
+        SELECT * FROM lp_amount_history
+        WHERE pairAddr = ? AND timestamp >= ?
+        ORDER BY timestamp ASC
+        LIMIT 1
+      `,
+      pairAddr,
+      timestamp
+    );
+    return result[0] as PoolAmountHistory;
+  }
+
   async insertPoolAmountHistory(ops: PoolAmountHistory[]) {
     await this.insertBulkData(ops, "lp_amount_history");
   }

--- a/packages/oraidex-sync/src/helper.ts
+++ b/packages/oraidex-sync/src/helper.ts
@@ -364,7 +364,7 @@ export function getSwapDirection(offerDenom: string, askDenom: string): SwapDire
     return pair.asset_infos.some((info) => info === offerDenom) && pair.asset_infos.some((info) => info === askDenom);
   });
   if (!pair) {
-    console.error("Cannot find asset infos in list of pairs");
+    console.error("getSwapDirection: Cannot find asset infos in list of pairs");
     return;
   }
   const assetInfos = pair.asset_infos;

--- a/packages/oraidex-sync/src/pool-helper.ts
+++ b/packages/oraidex-sync/src/pool-helper.ts
@@ -71,7 +71,6 @@ export const getPairByAssetInfos = (assetInfos: [AssetInfo, AssetInfo]): PairMap
 };
 
 // get price ORAI in USDT base on ORAI/USDT pool.
-// async function getOraiPrice(): Promise<number> {
 export const getOraiPrice = async (): Promise<number> => {
   const oraiUsdtPair = getPairByAssetInfos([oraiInfo, usdtInfo]);
   const ratioDirection: RatioDirection =
@@ -292,7 +291,6 @@ export const triggerCalculateApr = async (assetInfos: [AssetInfo, AssetInfo][], 
   const allRewardPerSecs = poolAprInfos.map((info) => (info.rewardPerSec ? JSON.parse(info.rewardPerSec) : null));
 
   const APRs = await calculateAprResult(allLiquidities, allTotalSupplies, allBondAmounts, allRewardPerSecs);
-  console.dir({ APRs }, { depth: null });
   const newPoolAprs = poolAprInfos.map((poolApr, index) => {
     return {
       ...poolApr,

--- a/packages/oraidex-sync/src/pool-helper.ts
+++ b/packages/oraidex-sync/src/pool-helper.ts
@@ -28,7 +28,7 @@ import {
   queryPoolInfos
 } from "./query";
 import { processEventApr } from "./tx-parsing";
-import { PairInfoData, PairMapping, ProvideLiquidityOperationData } from "./types";
+import { PairInfoData, PairMapping, PoolAmountHistory, ProvideLiquidityOperationData } from "./types";
 // use this type to determine the ratio of price of base to the quote or vice versa
 export type RatioDirection = "base_in_quote" | "quote_in_base";
 
@@ -71,21 +71,35 @@ export const getPairByAssetInfos = (assetInfos: [AssetInfo, AssetInfo]): PairMap
 };
 
 // get price ORAI in USDT base on ORAI/USDT pool.
-export const getOraiPrice = async (): Promise<number> => {
+export const getOraiPrice = async (timestamp?: number): Promise<number> => {
   const oraiUsdtPair = getPairByAssetInfos([oraiInfo, usdtInfo]);
   const ratioDirection: RatioDirection =
     parseAssetInfoOnlyDenom(oraiUsdtPair.asset_infos[0]) === ORAI ? "base_in_quote" : "quote_in_base";
-  return getPriceByAsset([oraiInfo, usdtInfo], ratioDirection);
+  return getPriceByAsset([oraiInfo, usdtInfo], ratioDirection, timestamp);
 };
 
+/**
+ * Get price of asset via askPoolAmount & offerPoolAmount in specific timestamp
+ * @param assetInfos
+ * @param ratioDirection
+ * @param timestamp
+ * @returns price of asset in specific time.
+ */
 export const getPriceByAsset = async (
   assetInfos: [AssetInfo, AssetInfo],
-  ratioDirection: RatioDirection
+  ratioDirection: RatioDirection,
+  timestamp?: number
 ): Promise<number> => {
   const duckDb = DuckDb.instances;
   const poolInfo = await duckDb.getPoolByAssetInfos(assetInfos);
   if (!poolInfo) return 0;
-  const poolAmount = await duckDb.getLatestLpPoolAmount(poolInfo.pairAddr);
+
+  let poolAmount: PoolAmountHistory;
+  if (timestamp) {
+    poolAmount = await duckDb.getLpAmountWithTime(poolInfo.pairAddr, timestamp);
+  } else {
+    poolAmount = await duckDb.getLatestLpPoolAmount(poolInfo.pairAddr);
+  }
   if (!poolAmount || !poolAmount.askPoolAmount || !poolAmount.offerPoolAmount) return 0;
   // offer: orai, ask: usdt -> price offer in ask = calculatePriceByPool([ask, offer])
   // offer: orai, ask: atom -> price ask in offer  = calculatePriceByPool([offer, ask])


### PR DESCRIPTION
What is purpose of the changes?

  - Create api get /orai-info to provide orai price & volume that serves for [pricefeed]https://pricefeed.oraichainlabs.org/ & chart Oraidex 3.0