### PR TITLE
fix: use bigdecimal to prevent crash when calculateMinReceice swap

### DIFF
--- a/packages/oraidex-common/package.json
+++ b/packages/oraidex-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oraichain/oraidex-common",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "main": "build/index.js",
   "files": [
     "build/"

--- a/packages/oraidex-common/src/helper.ts
+++ b/packages/oraidex-common/src/helper.ts
@@ -13,6 +13,7 @@ import { AVERAGE_COSMOS_GAS_PRICE, WRAP_BNB_CONTRACT, WRAP_ETH_CONTRACT, atomic,
 import { CoinGeckoId, NetworkChainId } from "./network";
 import { AmountDetails, TokenInfo, TokenItemType, cosmosTokens, flattenTokens, oraichainTokens } from "./token";
 import { StargateMsg, Tx } from "./tx";
+import { BigDecimal } from "./bigdecimal";
 
 export const getEvmAddress = (bech32Address: string) => {
   if (!bech32Address) throw new Error("bech32 address is empty");
@@ -154,8 +155,11 @@ export const calculateMinReceive = (
   userSlippage: number,
   decimals: number
 ): Uint128 => {
-  const amount = BigInt(simulateAverage) * BigInt(fromAmount);
-  return ((BigInt(Math.trunc(toDisplay(amount, decimals))) * (100n - BigInt(userSlippage))) / 100n).toString();
+  return new BigDecimal(simulateAverage)
+    .mul(fromAmount)
+    .mul((100 - userSlippage) / 100)
+    .div(10n ** BigInt(decimals))
+    .toString();
 };
 
 export const parseTokenInfo = (tokenInfo: TokenItemType, amount?: string): { fund?: Coin; info: AssetInfo } => {

--- a/packages/oraidex-common/tests/helper.spec.ts
+++ b/packages/oraidex-common/tests/helper.spec.ts
@@ -133,11 +133,14 @@ describe("should helper functions in helper run exactly", () => {
     ["1800000", "100000", 1, 6, "178200"],
     ["1000000000000000000", "1000000000000000000", 1, 18, "990000000000000000"],
     ["1800000", "100000", 1.25, 6, "177750"],
-    ["1000000000000000000", "1000000000000000000", 1.5, 18, "985000000000000000"]
+    ["1000000000000000000", "1000000000000000000", 1.5, 18, "985000000000000000"],
+    ["180000.5", "10000.5", 1.25, 6, "1777.593812"],
+    ["100000000000000000.5", "100000000000000000.5", 1.5, 18, "9850000000000000.0985"]
   ])(
     "calculateMinReceive should return correctly minimum receive",
     (simulateAverage: string, fromAmount: string, userSlippage: number, decimals: number, expectedResult) => {
       const result = calculateMinReceive(simulateAverage, fromAmount, userSlippage, decimals);
+      console.log({ resultcalculateMinReceive: result });
       expect(result).toEqual(expectedResult);
     }
   );

--- a/packages/oraidex-common/tests/helper.spec.ts
+++ b/packages/oraidex-common/tests/helper.spec.ts
@@ -131,7 +131,9 @@ describe("should helper functions in helper run exactly", () => {
   it.each([
     ["1000000", "1000000", 1, 6, "990000"],
     ["1800000", "100000", 1, 6, "178200"],
-    ["1000000000000000000", "1000000000000000000", 1, 18, "990000000000000000"]
+    ["1000000000000000000", "1000000000000000000", 1, 18, "990000000000000000"],
+    ["1800000", "100000", 1.25, 6, "177750"],
+    ["1000000000000000000", "1000000000000000000", 1.5, 18, "985000000000000000"]
   ])(
     "calculateMinReceive should return correctly minimum receive",
     (simulateAverage: string, fromAmount: string, userSlippage: number, decimals: number, expectedResult) => {

--- a/packages/oraidex-server/package.json
+++ b/packages/oraidex-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oraichain/oraidex-server",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "main": "dist/index.js",
   "bin": "dist/index.js",
   "license": "MIT",

--- a/packages/oraidex-server/package.staging.json
+++ b/packages/oraidex-server/package.staging.json
@@ -1,6 +1,6 @@
 {
   "name": "@oraichain/oraidex-server-staging",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "main": "dist/index.js",
   "bin": "dist/index.js",
   "license": "MIT",

--- a/packages/oraidex-server/src/index.ts
+++ b/packages/oraidex-server/src/index.ts
@@ -454,14 +454,18 @@ app.get("/v1/my-staking", async (req: Request<{}, {}, {}, GetStakedByUserQuery>,
   }
 });
 
-app.listen(port, hostname, async () => {
-  // sync data for the service to read
-  duckDb = await DuckDb.create(process.env.DUCKDB_PROD_FILENAME);
-  const oraidexSync = await OraiDexSync.create(
-    duckDb,
-    process.env.RPC_URL || "https://rpc.orai.io",
-    process.env as any
-  );
-  oraidexSync.sync();
-  console.log(`[server]: oraiDEX info server is running at http://${hostname}:${port}`);
-});
+app
+  .listen(port, hostname, async () => {
+    // sync data for the service to read
+    duckDb = await DuckDb.create(process.env.DUCKDB_PROD_FILENAME);
+    const oraidexSync = await OraiDexSync.create(
+      duckDb,
+      process.env.RPC_URL || "https://rpc.orai.io",
+      process.env as any
+    );
+    oraidexSync.sync();
+    console.log(`[server]: oraiDEX info server is running at http://${hostname}:${port}`);
+  })
+  .on("error", () => {
+    process.exit(1);
+  });

--- a/packages/oraidex-sync/src/index.ts
+++ b/packages/oraidex-sync/src/index.ts
@@ -186,6 +186,7 @@ class OraiDexSync {
       }).pipe(new WriteOrders(this.duckDb));
     } catch (error) {
       console.log("error in start: ", error);
+      process.exit(1);
     }
   }
 }

--- a/packages/universal-swap/package.json
+++ b/packages/universal-swap/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@oraichain/oraidex-universal-swap",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "main": "build/index.js",
   "files": [
     "build/"
   ],
   "license": "MIT",
   "dependencies": {
-    "@oraichain/oraidex-common": "^1.0.31",
+    "@oraichain/oraidex-common": "^1.0.32",
     "@oraichain/oraidex-contracts-sdk": "^1.0.24",
     "bech32": "1.1.4",
     "ethers": "^5.0.15",


### PR DESCRIPTION
What is purpose of the changes?

 - Use bigdecimal to calculate minimum receive for universal swap