### PR TITLE
Fix get APR for pool detail

### DIFF
--- a/packages/oraidex-server/package.json
+++ b/packages/oraidex-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oraichain/oraidex-server",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "main": "dist/index.js",
   "bin": "dist/index.js",
   "license": "MIT",

--- a/packages/oraidex-server/package.staging.json
+++ b/packages/oraidex-server/package.staging.json
@@ -1,6 +1,6 @@
 {
   "name": "@oraichain/oraidex-server-staging",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "main": "dist/index.js",
   "bin": "dist/index.js",
   "license": "MIT",

--- a/packages/oraidex-server/src/index.ts
+++ b/packages/oraidex-server/src/index.ts
@@ -40,7 +40,7 @@ import express, { Request } from "express";
 import fs from "fs";
 import path from "path";
 import { getDate24hBeforeNow, getSpecificDateBeforeNow, pairToString, parseSymbolsToTickerId } from "./helper";
-import { AssetInfo } from "@oraichain/common-contracts-sdk";
+import { AssetInfo } from "@oraichain/oraidex-contracts-sdk";
 
 const app = express();
 app.use(cors());
@@ -270,16 +270,19 @@ app.get("/v1/pools/", async (_req, res) => {
 });
 
 app.get("/v1/pool-detail", async (req: Request<{}, {}, {}, GetPoolDetailQuery>, res) => {
-  if (!req.query.pairDenoms) return res.status(400).send("Not enough query params: pairDenoms");
+  const { pairDenoms } = req.query;
+  if (!pairDenoms) return res.status(400).send("Not enough query params: pairDenoms");
 
   try {
-    const [baseDenom, quoteDenom] = req.query.pairDenoms && req.query.pairDenoms.split("_");
+    const [baseDenom, quoteDenom] = pairDenoms && pairDenoms.split("_");
     const pair = pairWithStakingAsset.find((pair) =>
       isEqual(
         pair.asset_infos.map((asset_info) => parseAssetInfoOnlyDenom(asset_info)),
         [baseDenom, quoteDenom]
       )
     );
+    if (!pair) throw new Error(`Cannot find pair with denoms: ${pairDenoms}`);
+
     const tf = 24 * 60 * 60; // second of 24h
     const currentDate = new Date();
     const oneDayBeforeNow = getSpecificDateBeforeNow(new Date(), tf);
@@ -295,7 +298,7 @@ app.get("/v1/pool-detail", async (req: Request<{}, {}, {}, GetPoolDetailQuery>, 
       percentVolumeChange = (Number(poolVolume - poolVolumeOnedayBefore) / Number(poolVolumeOnedayBefore)) * 100;
     }
 
-    const poolApr = await duckDb.getAprPool(pool.pairAddr);
+    const poolApr = await duckDb.getLatestPoolApr(pool.pairAddr);
     const poolLiquidity = await getPairLiquidity(pool);
     const poolDetailResponse = {
       ...pool,

--- a/packages/oraidex-sync/src/db.ts
+++ b/packages/oraidex-sync/src/db.ts
@@ -534,7 +534,7 @@ export class DuckDb {
     await this.insertBulkData(ops, "lp_amount_history");
   }
 
-  async createAprInfoPair() {
+  async createPoolAprTable() {
     await this.conn.exec(
       `CREATE TABLE IF NOT EXISTS pool_apr (
           uniqueKey varchar UNIQUE,
@@ -543,10 +543,14 @@ export class DuckDb {
           totalSupply varchar,
           totalBondAmount varchar,
           rewardPerSec varchar,
-          apr double,
+          apr double
         )
       `
     );
+  }
+
+  async addTimestampColToPoolAprTable() {
+    await this.conn.run(`ALTER TABLE pool_apr ADD COLUMN IF NOT EXISTS timestamp UBIGINT DEFAULT 0`);
   }
 
   async insertPoolAprs(poolAprs: PoolApr[]) {
@@ -558,7 +562,7 @@ export class DuckDb {
       `
         SELECT * FROM pool_apr
         WHERE pairAddr = ?
-        ORDER BY height DESC
+        ORDER BY timestamp DESC
         LIMIT 1
       `,
       pairAddr
@@ -572,7 +576,7 @@ export class DuckDb {
       `
       WITH RankedPool AS (
         SELECT pairAddr, apr, rewardPerSec, totalSupply, height,
-               ROW_NUMBER() OVER (PARTITION BY pairAddr ORDER BY height DESC) AS rn
+               ROW_NUMBER() OVER (PARTITION BY pairAddr ORDER BY timestamp DESC) AS rn
         FROM pool_apr
     )
     SELECT pairAddr, apr, rewardPerSec, totalSupply
@@ -581,18 +585,6 @@ export class DuckDb {
       `
     );
     return result as Pick<PoolApr, "apr" | "pairAddr" | "rewardPerSec" | "totalSupply">[];
-  }
-
-  async getAprPool(pairAddr: string) {
-    const result = await this.conn.all(
-      `
-      SELECT * FROM pool_apr
-      WHERE pairAddr = ?
-      ORDER BY height DESC
-      `,
-      pairAddr
-    );
-    return result[0] as PoolApr;
   }
 
   async createStakingHistoryTable() {

--- a/packages/oraidex-sync/src/index.ts
+++ b/packages/oraidex-sync/src/index.ts
@@ -1,7 +1,12 @@
 import { SyncData, Txs, WriteData } from "@oraichain/cosmos-rpc-sync";
 import "dotenv/config";
 import { DuckDb } from "./db";
-import { concatLpHistoryToUniqueKey, getPairLiquidity, getSymbolFromAsset } from "./helper";
+import {
+  concatAprHistoryToUniqueKey,
+  concatLpHistoryToUniqueKey,
+  getPairLiquidity,
+  getSymbolFromAsset
+} from "./helper";
 import { parseAssetInfo, parsePoolAmount } from "./parse";
 import { fetchAprResult, getAllPairInfos, getPairByAssetInfos, getPoolInfos, handleEventApr } from "./pool-helper";
 import { parseTxs } from "./tx-parsing";
@@ -133,13 +138,21 @@ class OraiDexSync {
 
     const poolAprs = allAprs.map((apr, index) => {
       return {
-        uniqueKey: concatLpHistoryToUniqueKey({ timestamp: height, pairAddr: pools[index].pairAddr }),
+        uniqueKey: concatAprHistoryToUniqueKey({
+          timestamp: Date.now(),
+          supply: allTotalSupplies[index],
+          bond: allBondAmounts[index],
+          reward: JSON.stringify(allRewardPerSec[index]),
+          apr,
+          pairAddr: pools[index].pairAddr
+        }),
         pairAddr: pools[index].pairAddr,
         height,
         totalSupply: allTotalSupplies[index],
         totalBondAmount: allBondAmounts[index],
         rewardPerSec: JSON.stringify(allRewardPerSec[index]),
-        apr
+        apr,
+        timestamp: Date.now()
       } as PoolApr;
     });
     await this.duckDb.insertPoolAprs(poolAprs);
@@ -155,9 +168,10 @@ class OraiDexSync {
         this.duckDb.createPairInfosTable(),
         this.duckDb.createSwapOhlcv(),
         this.duckDb.createLpAmountHistoryTable(),
-        this.duckDb.createAprInfoPair(),
+        this.duckDb.createPoolAprTable(),
         this.duckDb.createStakingHistoryTable(),
-        this.duckDb.createEarningHistoryTable()
+        this.duckDb.createEarningHistoryTable(),
+        this.duckDb.addTimestampColToPoolAprTable()
       ]);
       let currentInd = await this.duckDb.loadHeightSnapshot();
       const initialSyncHeight = parseInt(process.env.INITIAL_SYNC_HEIGHT) || 12388825;

--- a/packages/oraidex-sync/src/pool-helper.ts
+++ b/packages/oraidex-sync/src/pool-helper.ts
@@ -326,7 +326,8 @@ export const triggerCalculateApr = async (assetInfos: [AssetInfo, AssetInfo][], 
         reward: allRewardPerSecs[index],
         apr: APRs[index],
         pairAddr: pools[index].pairAddr
-      })
+      }),
+      timestamp: Date.now()
     };
   });
   await duckDb.insertPoolAprs(newPoolAprs);
@@ -367,7 +368,8 @@ export const refetchInfoApr = async (
     return {
       ...poolApr,
       height,
-      [type]: newInfos[index]
+      [type]: newInfos[index],
+      timestamp: Date.now()
     };
   });
   await duckDb.insertPoolAprs(newPoolAprs);
@@ -415,7 +417,7 @@ export const getListAssetInfoShouldRefetchApr = async (txs: Tx[], lpOps: Provide
     .filter(Boolean);
 
   if (isTriggerRewardPerSec) {
-    // update_reward_per_sec trigger refetch all info
+    // update_reward_per_sec trigger refetch all info, so we clear listAssetInfosPoolShouldRefetch then add all assetInfo from pairs.
     listAssetInfosPoolShouldRefetch.clear();
     pairs.map((pair) => pair.asset_infos).forEach((assetInfos) => listAssetInfosPoolShouldRefetch.add(assetInfos));
   } else {

--- a/packages/oraidex-sync/src/pool-helper.ts
+++ b/packages/oraidex-sync/src/pool-helper.ts
@@ -327,7 +327,7 @@ export const triggerCalculateApr = async (assetInfos: [AssetInfo, AssetInfo][], 
         apr: APRs[index],
         pairAddr: pools[index].pairAddr
       }),
-      timestamp: Date.now()
+      timestamp: Date.now() // use timestamp date.now() because we just need to have a order of apr.
     };
   });
   await duckDb.insertPoolAprs(newPoolAprs);
@@ -450,6 +450,8 @@ export const handleEventApr = async (
     refetchInfoApr("totalBondAmount", assetInfosTriggerTotalBond, newOffset)
   ]);
 
+  // after refetchInfoApr above, we updated infos can impact to APR: totalSupply, rewardPerSec, totalBondAmount
+  // so we re-calculate APR and accumulate to pool_apr table.
   await triggerCalculateApr(Array.from(listAssetInfosPoolShouldRefetch), newOffset);
 };
 

--- a/packages/oraidex-sync/src/tx-parsing.ts
+++ b/packages/oraidex-sync/src/tx-parsing.ts
@@ -568,7 +568,7 @@ export const processEventApr = (txs: Tx[]) => {
     isTriggerRewardPerSec: false
   };
   for (let tx of txs) {
-    // guard code. Should refetch all token info if match event update_rewards_per_sec or length ofstaking asset equal to pairs length.
+    // guard code. Should refetch all token info if match event update_rewards_per_sec or length of staking asset equal to pairs length.
     if (assets.isTriggerRewardPerSec || assets.infoTokenAssetPools.size === pairs.length) break;
 
     const msgExecuteContracts = parseTxToMsgExecuteContractMsgs(tx);

--- a/packages/oraidex-sync/src/types.ts
+++ b/packages/oraidex-sync/src/types.ts
@@ -270,6 +270,7 @@ export type PoolApr = {
   totalBondAmount: string;
   rewardPerSec: string;
   apr: number;
+  timestamp: number;
 };
 
 export type GetPricePairQuery = {

--- a/packages/oraidex-sync/tests/db.spec.ts
+++ b/packages/oraidex-sync/tests/db.spec.ts
@@ -433,7 +433,8 @@ describe("test-duckdb", () => {
     beforeEach(async () => {
       // setup
       duckDb = await DuckDb.create(":memory:");
-      await duckDb.createAprInfoPair();
+      await duckDb.createPoolAprTable();
+      await duckDb.addTimestampColToPoolAprTable();
       await duckDb.insertPoolAprs([
         {
           uniqueKey: "orai_usdt_2",
@@ -442,7 +443,18 @@ describe("test-duckdb", () => {
           totalSupply: "1",
           totalBondAmount: "1",
           rewardPerSec: "1",
-          apr: 2
+          apr: 2,
+          timestamp: 1234
+        },
+        {
+          uniqueKey: "orai_usdt_1",
+          pairAddr: "orai_usdt",
+          height: 2,
+          totalSupply: "1",
+          totalBondAmount: "1",
+          rewardPerSec: "1",
+          apr: 2.5,
+          timestamp: 1236
         },
         {
           uniqueKey: "orai_usdt_4",
@@ -451,7 +463,8 @@ describe("test-duckdb", () => {
           totalSupply: "1",
           totalBondAmount: "1",
           rewardPerSec: "1",
-          apr: 4
+          apr: 4,
+          timestamp: 1235
         },
         {
           uniqueKey: "orai_usdt_3",
@@ -460,7 +473,8 @@ describe("test-duckdb", () => {
           totalSupply: "1",
           totalBondAmount: "1",
           rewardPerSec: "1",
-          apr: 3
+          apr: 3,
+          timestamp: 1233
         },
         {
           uniqueKey: "orai_atom",
@@ -469,7 +483,8 @@ describe("test-duckdb", () => {
           totalSupply: "1",
           totalBondAmount: "1",
           rewardPerSec: "1",
-          apr: 2
+          apr: 2,
+          timestamp: 1234
         }
       ]);
     });
@@ -480,7 +495,7 @@ describe("test-duckdb", () => {
 
       // assertion
       expect(apr).toEqual([
-        { pairAddr: "orai_usdt", apr: 4, rewardPerSec: "1", totalSupply: "1" },
+        { pairAddr: "orai_usdt", apr: 2.5, rewardPerSec: "1", totalSupply: "1" },
         { pairAddr: "orai_atom", apr: 2, rewardPerSec: "1", totalSupply: "1" }
       ]);
     });
@@ -491,13 +506,14 @@ describe("test-duckdb", () => {
 
       // assertion
       expect(result).toMatchObject({
-        uniqueKey: "orai_usdt_4",
+        uniqueKey: "orai_usdt_1",
         pairAddr: "orai_usdt",
-        height: 4,
+        height: 2,
         totalSupply: "1",
         totalBondAmount: "1",
         rewardPerSec: "1",
-        apr: 4
+        apr: 2.5,
+        timestamp: 1236
       });
     });
   });


### PR DESCRIPTION
What is purpose of the changes?

 - Add column timestamp to table pool_apr to get APR order by timestamp instead of height, because duplicate height can lead to return wrong order of APR
 - Refactor some logics to make it cleaner