### PR TITLE
fix: revert order to display in Coingecko

### DIFF
--- a/packages/oraidex-server/package.json
+++ b/packages/oraidex-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oraichain/oraidex-server",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "main": "dist/index.js",
   "bin": "dist/index.js",
   "license": "MIT",

--- a/packages/oraidex-server/package.staging.json
+++ b/packages/oraidex-server/package.staging.json
@@ -1,6 +1,6 @@
 {
   "name": "@oraichain/oraidex-server-staging",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "main": "dist/index.js",
   "bin": "dist/index.js",
   "license": "MIT",

--- a/packages/oraidex-server/package.staging.json
+++ b/packages/oraidex-server/package.staging.json
@@ -1,6 +1,6 @@
 {
   "name": "@oraichain/oraidex-server-staging",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "main": "dist/index.js",
   "bin": "dist/index.js",
   "license": "MIT",

--- a/packages/oraidex-server/src/index.ts
+++ b/packages/oraidex-server/src/index.ts
@@ -158,9 +158,6 @@ app.get("/tickers", async (req, res) => {
           try {
             // reverse because in pairs, we put base info as first index
             const price = await simulateSwapPrice(pair.asset_infos, routerContract);
-            if (pairAddr === "orai1n4edv5h86rawzrvhy8lmrmnnmmherxnhuwqnk3yuvt0wgclh75usyn3md6") {
-              console.log({ price });
-            }
             tickerInfo.last_price = price.toString();
           } catch (error) {
             tickerInfo.last_price = "0";

--- a/packages/oraidex-sync/src/pairs.ts
+++ b/packages/oraidex-sync/src/pairs.ts
@@ -97,7 +97,7 @@ export const pairs: PairMapping[] = [
   {
     asset_infos: [{ token: { contract_addr: usdcCw20Address } }, { token: { contract_addr: oraixCw20Address } }],
     lp_token: pairLpTokens.USDC_ORAIX,
-    symbols: ["ORAIX", "USDC"]
+    symbols: ["USDC", "ORAIX"]
   }
 ];
 

--- a/packages/oraidex-sync/src/query.ts
+++ b/packages/oraidex-sync/src/query.ts
@@ -67,7 +67,7 @@ async function simulateSwapPrice(pairPath: AssetInfo[], router: OraiswapRouterRe
     pairPath.some((assetInfo) => parseAssetInfoOnlyDenom(assetInfo) === usdcCw20Address);
   const THOUDAND_AMOUNT_IN_DECIMAL_SIX = 1000000000;
   const offerAmount = isSimulateOraixUsdc ? THOUDAND_AMOUNT_IN_DECIMAL_SIX : tenAmountInDecimalSix;
-  const sourceDecimals = isSimulateOraixUsdc ? 9 : 6;
+  const sourceDecimals = isSimulateOraixUsdc ? 9 : 7;
   try {
     const data = await router.simulateSwapOperations({
       offerAmount: offerAmount.toString(),

--- a/packages/oraidex-sync/tests/helper.spec.ts
+++ b/packages/oraidex-sync/tests/helper.spec.ts
@@ -231,7 +231,7 @@ describe("test-helper", () => {
       {
         asset_infos: [{ token: { contract_addr: usdcCw20Address } }, { token: { contract_addr: oraixCw20Address } }],
         lp_token: pairLpTokens.USDC_ORAIX,
-        symbols: ["ORAIX", "USDC"]
+        symbols: ["USDC", "ORAIX"]
       }
     ]);
   });

--- a/packages/universal-swap/package.json
+++ b/packages/universal-swap/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@oraichain/oraidex-universal-swap",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "main": "build/index.js",
   "files": [
     "build/"
   ],
   "scripts": {
-    "build":"tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json"
   },
   "license": "MIT",
   "dependencies": {
-    "@oraichain/oraidex-common": "^1.0.34",
+    "@oraichain/oraidex-common": "^1.0.43",
     "@oraichain/oraidex-contracts-sdk": "^1.0.24",
     "bech32": "1.1.4",
     "ethers": "^5.0.15",


### PR DESCRIPTION
What is purpose of the changes?

 - Fix error return wrong volume, price of pair ORAIX/USDC, current we hardcode simulate with amount 1000 instead 10 to prevent error simulate of contract