### PR TITLE
fix: resolve all dependencies of common package

### DIFF
--- a/packages/oraidex-common/package.json
+++ b/packages/oraidex-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oraichain/oraidex-common",
-  "version": "1.0.54",
+  "version": "1.0.55",
   "main": "build/index.js",
   "files": [
     "build/"
@@ -12,7 +12,16 @@
   "dependencies": {
     "@ethersproject/providers": "^5.0.10",
     "ethers": "^5.0.15",
-    "@keplr-wallet/types": "^0.11.38"
+    "@keplr-wallet/types": "^0.11.38",
+    "@cosmjs/amino": "^0.31.0",
+    "@cosmjs/cosmwasm-stargate": "^0.31.0",
+    "@cosmjs/crypto": "^0.31.0",
+    "@cosmjs/proto-signing": "^0.31.0",
+    "@cosmjs/stargate": "^0.31.0",
+    "@cosmjs/tendermint-rpc": "0.31.0",
+    "bignumber.js":"^9.0.1",
+    "cosmjs-types": "^0.8.0",
+    "@oraichain/oraidex-contracts-sdk":"^1.0.30"
   },
   "devDependencies": {},
   "resolutions": {


### PR DESCRIPTION
The problems is missing dependencies in package.json, it will occur when your own project which installed this `common` do not have sufficient dependencies of `common`

<img width="1507" alt="image" src="https://github.com/oraichain/oraidex-sdk/assets/58201417/7371cea0-cc3f-48e1-92f9-c84ce1b95154">
