### PR TITLE
hotfix: fix error related bigint in duckdb v9

### DIFF
--- a/packages/oraidex-sync/src/db.ts
+++ b/packages/oraidex-sync/src/db.ts
@@ -307,8 +307,9 @@ export class DuckDb {
 
     // get second
     result.forEach((item) => {
-      item.time *= tf;
+      item.time *= BigInt(+tf * 60);
     });
+
     return result as Ohlcv[];
   }
 


### PR DESCRIPTION
What is purpose of the changes?

 - Fix error cannot mix bigint with other occured when upgrade duckdb v9