### PR TITLE
sonarqube: add exclusions

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,6 @@
 sonar.projectKey=oraichain_oraidex-sdk
 sonar.organization=oraichain
+sonar.exclusions=docs,packages/contracts-sdk,packages/oraidex-common/src/typechain-types
 
 # This is the name and version displayed in the SonarCloud UI.
 #sonar.projectName=oraidex-sdk


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Sonar project settings to exclude specific directories (`docs`, `packages/contracts-sdk`, and `packages/oraidex-common/src/typechain-types`) from analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->