### PR TITLE
common: 1.0.92 . swap: 1.0.93

### DIFF
--- a/packages/oraidex-common/package.json
+++ b/packages/oraidex-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oraichain/oraidex-common",
-  "version": "1.0.91",
+  "version": "1.0.92",
   "main": "build/index.js",
   "files": [
     "build/"

--- a/packages/universal-swap/package.json
+++ b/packages/universal-swap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oraichain/oraidex-universal-swap",
-  "version": "1.0.92",
+  "version": "1.0.93",
   "main": "build/index.js",
   "files": [
     "build/"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["ES2020", "dom"],
-    "module": "ES2020",
+    "module": "commonjs",
     "moduleResolution": "node",
     "skipLibCheck": true,
     "sourceMap": true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated version for `@oraichain/oraidex-common` to 1.0.92.
  - Updated version for `@oraichain/oraidex-universal-swap` to 1.0.93.
  
- **Refactor**
  - Changed TypeScript module system from ES2020 to CommonJS for broader compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->